### PR TITLE
Patch 6C

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,1 +1,2 @@
 require("data.starmap")
+require("data.compatibility.mod-compat-space-location")

--- a/data/compatibility/mod-compat-space-location.lua
+++ b/data/compatibility/mod-compat-space-location.lua
@@ -1,0 +1,16 @@
+if mods["visible-planets"] then
+    for _,space_location in pairs(data.raw["space-location"]) do
+        if space_location.mod and space_location.mod == "rsu" then
+            if string.find(space_location.name, "asteroid%-belt") then
+                vp_add_planets_to_blacklist({space_location.name})
+            end
+        end
+    end
+    for _,planet in pairs(data.raw["planet"]) do
+        if planet.mod and planet.mod == "rsu" then
+            if string.find(planet.name, "asteroid%-belt") then
+                vp_add_planets_to_blacklist({planet.name})
+            end
+        end
+    end
+end

--- a/info.json
+++ b/info.json
@@ -8,7 +8,8 @@
     "dependencies": [
         "space-age",
         "alien-biomes",
-        "maraxsis"
+        "maraxsis",
+        "? visible-planets >= 1.1.6"
     ],
     "factorio_version": "2.0",
     "space_travel_required": true,


### PR DESCRIPTION
Subpatch 3 of Patch 6. This subpatch is **Tested** and there are no obvious issues with this subpatch.

- Disable asteroid belt images being shown as "Visible" when the visible planets mod is enabled.
- Ensure that the visible planets mod is version 1.2.6 or later if installed.
- Fix issues caused by implementation of the above features.
- Fix #30 